### PR TITLE
对调船名和等级的位置

### DIFF
--- a/parts/prophet-info.cjsx
+++ b/parts/prophet-info.cjsx
@@ -30,7 +30,7 @@ module.exports = React.createClass
       <td>　</td>
     else
       <td style={opacity: 1 - 0.6 * @props.isBack}>
-        Lv. {@props.lv} - {@props.name}
+        {@props.name} Lv.{@props.lv} 
         {
           if @props.cond && @props.condShow != 0
             <span style={getCondStyle @props.cond}>


### PR DESCRIPTION
在横版且右栏宽度较小时，会只显示等级而不显示船名。
![screen shot 2015-08-26 at 2 19 35 pm](https://cloud.githubusercontent.com/assets/3337921/9486738/aae281e8-4bfd-11e5-9145-388bababdcd4.png)

在这种显示不全的情况下，船名先比等级更重要。
所以对调一下位置，保证宽度不足的时候依旧能显示船名。