### PR TITLE
Made ship names look better on small panels

### DIFF
--- a/parts/prophet-info.cjsx
+++ b/parts/prophet-info.cjsx
@@ -2,22 +2,22 @@
 
 getCondStyle = (cond) ->
   if window.theme.indexOf('dark') != -1 or window.theme == 'slate' or window.theme == 'superhero'
-    if cond > 52
+    if cond > 52 # 53~100
       color: '#FFFF00',
       fontWeight: 'bold',
       textShadow: '0 0 7px #FFFF00'
-    else if cond > 49
+    else if cond > 49 # 50~52
       color: '#FFFF80'
-    else if cond is 49
+    else if cond is 49 # 49
       {}
-    else if cond < 48
-      opacity: 0.5
-    else if cond < 40
-      color: '#FFC880'
-    else if cond < 30
-      color: '#F37B1D'
-    else # if cond < 20
+    else if cond < 20 # 0~19
       color: '#DD514C'
+    else if cond < 30 # 20~29
+      color: '#F37B1D'
+    else if cond < 40 # 30~39
+      color: '#FFC880'
+    else # 40~48
+      opacity: 0.5
   else
     if cond > 52
       textShadow: '0 0 3px #FFFF00'

--- a/parts/prophet-info.cjsx
+++ b/parts/prophet-info.cjsx
@@ -2,19 +2,27 @@
 
 getCondStyle = (cond) ->
   if window.theme.indexOf('dark') != -1 or window.theme == 'slate' or window.theme == 'superhero'
-    if cond > 49
-      color: '#FFFF00'
-    else if cond < 20
-      color: '#DD514C'
-    else if cond < 30
-      color: '#F37B1D'
+    if cond > 52
+      color: '#FFFF00',
+      fontWeight: 'bold',
+      textShadow: '0 0 7px #FFFF00'
+    else if cond > 49
+      color: '#FFFF80'
+    else if cond is 49
+      {}
+    else if cond < 48
+      opacity: 0.5
     else if cond < 40
       color: '#FFC880'
-    else
-      null
+    else if cond < 30
+      color: '#F37B1D'
+    else # if cond < 20
+      color: '#DD514C'
   else
-    if cond > 49
+    if cond > 52
       textShadow: '0 0 3px #FFFF00'
+    else if cond > 49
+      textShadow: '0 0 3px #FFFF80'
     else if cond < 20
       textShadow: '0 0 3px #DD514C'
     else if cond < 30
@@ -30,11 +38,15 @@ module.exports = React.createClass
       <td>　</td>
     else
       <td style={opacity: 1 - 0.6 * @props.isBack}>
-        Lv. {@props.lv} - {@props.name}
         {
+          txt = "#{@props.name}(#{@props.lv})"
+          title = "#{@props.name}(Lv.#{@props.lv})"
           if @props.cond && @props.condShow != 0
-            <span style={getCondStyle @props.cond}>
-              <FontAwesome key={1} name='star' />{@props.cond}
+            title += " Cond.#{@props.cond}"
+            <span style={getCondStyle @props.cond} title={title}>
+              {txt}<FontAwesome key={1} name='star' />{@props.cond}
             </span>
+          else
+            <span title={title}>{txt}</span>
         }
       </td>


### PR DESCRIPTION
* Changed order of Lv/name/cond, and made it shorter:
`Lv. 100 - name ⭐️99`
=>
`name(100)⭐️99`
* Colourise the entire text, not only the cond part (which is usually
hidden when combined fleet is in use).
* More colours and text effects to show more detailed conditions.
* Added tooltips to show complete information.