### PR TITLE
Provide api_id context for enemy translations

### DIFF
--- a/views/item-view.es
+++ b/views/item-view.es
@@ -40,7 +40,10 @@ const ItemView = compose(
       </span>
       <span className="item-name">
         {/* use key separator because some item name contains `.` */}
-        {t(data.api_name, { keySeparator: 'chiba' })}
+        {t(data.api_name, {
+          context: data.api_id && data.api_id.toString(),
+          keySeparator: 'chiba',
+        })}
       </span>
       <span className="item-attr">
         <span className="alv">

--- a/views/ship-view.es
+++ b/views/ship-view.es
@@ -58,14 +58,15 @@ const getTextWidth = text => {
   return Math.ceil(metrics.width)
 }
 
-const yomis = ['elite', 'flagship']
-
 const getFullname = (t, name, yomi, apiId) => {
-  const translated = t(name, { context: apiId && apiId.toString() })
-  return yomis.includes(yomi) &&
-    !yomis.some(e => translated.match(` ${_.capitalize(e)}`))
-    ? `${translated} ${_.capitalize(yomi)}`
-    : translated
+  const baseName = t(name)
+  const fullName = t(name, { context: apiId && apiId.toString() })
+  return (
+    (fullName !== baseName && fullName) ||
+    (['elite', 'flagship'].includes(yomi)
+      ? `${baseName} ${_.capitalize(yomi)}`
+      : baseName)
+  )
 }
 
 const ShipName = translate('resources')(({ name, yomi, apiId, enemy, t }) => {


### PR DESCRIPTION
As mentioned in https://github.com/poooi/plugin-translator/issues/24, better translations can be provided if `api_id` is present in context.