### PR TITLE
Toggle for displaying air raid results.

### DIFF
--- a/assets/i18n/ja-JP.json
+++ b/assets/i18n/ja-JP.json
@@ -74,6 +74,7 @@
   "Combined Fleet": "連合艦隊",
   "A_rank": "A 勝：",
   "Enable avatars": "アバターを表示する",
+  "Display air raid results": "空襲の結果を表示する",
   "Layout": "レイアウト",
   "Auto": "適応",
   "Horizontal": "左右",

--- a/assets/i18n/zh-CN.json
+++ b/assets/i18n/zh-CN.json
@@ -74,6 +74,7 @@
   "Combined Fleet": "联合舰队",
   "A_rank": "A 胜：",
   "Enable avatars": "显示头像",
+  "Display air raid results": "显示空袭结果",
   "Layout": "布局",
   "Auto": "自适应",
   "Horizontal": "左右",

--- a/assets/i18n/zh-TW.json
+++ b/assets/i18n/zh-TW.json
@@ -74,6 +74,7 @@
   "Combined Fleet": "聯合艦隊",
   "A_rank": "A 勝：",
   "Enable avatars": "顯示頭像",
+  "Display air raid results": "顯示空襲結果",
   "Layout": "佈局",
   "Auto": "自適應",
   "Horizontal": "左右",

--- a/src/index.es
+++ b/src/index.es
@@ -129,6 +129,7 @@ class ProphetBase extends Component {
     fleetIds: PropTypes.arrayOf(PropTypes.number),
     t: PropTypes.func.isRequired,
     layout: PropTypes.string.isRequired,
+    showAirRaid: PropTypes.bool.isRequired,
   }
 
   root = React.createRef()
@@ -259,7 +260,7 @@ class ProphetBase extends Component {
   }
 
   handleGameResponse = e => {
-    const { t, fleets, equips, sortie } = this.props
+    const { t, fleets, equips, sortie, showAirRaid } = this.props
     const { path, body } = e.detail
     // used in determining next spot type
 
@@ -321,7 +322,7 @@ class ProphetBase extends Component {
           airForce,
         } = this.constructor.initState)
         // land base air raid
-        if (api_destruction_battle != null) {
+        if (showAirRaid && api_destruction_battle != null) {
           const destructionBattleArray = Array.isArray(api_destruction_battle)
             ? api_destruction_battle
             : [api_destruction_battle]
@@ -598,13 +599,15 @@ export const Prophet = compose(
     const equips = fleetIds.map(i =>
       fleetShipsEquipDataSelectorFactory(i)(state),
     )
+    const config = get(state, 'config.plugin.prophet')
     return {
       sortie,
       airbase,
       fleets,
       equips,
       fleetIds,
-      layout: get(state.config, 'plugin.prophet.layout', 'auto'),
+      layout: get(config, 'layout', 'auto'),
+      showAirRaid: get(config, 'showAirRaid', true),
     }
   }),
 )(ProphetBase)

--- a/src/views/settings-class/index.es
+++ b/src/views/settings-class/index.es
@@ -89,6 +89,11 @@ class SettingsClass extends Component {
             configName="plugin.prophet.showAvatar"
             defaultVal={false}
           />
+          <CheckboxLabelConfig
+            label={t('Display air raid results')}
+            configName="plugin.prophet.showAirRaid"
+            defaultVal={true}
+          />
         </CheckboxContainer>
         <Gap />
         <div>


### PR DESCRIPTION
Air raid result will replace the entire view, this makes it difficult to check ships' status after an air raid event and before entering a node. This patch provides an option to entire ignore this field.